### PR TITLE
Async API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQLite3-WinRT
 
-A set of SQLite wrappers for WinRT (Windows Metro) applications.
+Async SQLite for WinRT (Windows Metro) applications.
 
 ## Status
 
@@ -11,60 +11,38 @@ production use and Windows Store compatibility, and it will mature as the
 Windows 8 platform itself matures. Feedback and contributions are highly
 appreciated, feel free to open issues or pull requests on GitHub.
 
-## _SQLite3_
+## SQLite3JS Namespace
 
-This WinRT component provides an `SQLite3` namespace that can be used in C# and
-Javascript. It exposes the low-level SQLite API. C structs are "objectified",
-and function names are changed to follow the WinRT naming conventions, but
-other than that, it is a one-to-one copy of the original SQLite API.
+The SQLite3JS namespace provides an async JavaScript API for SQLite. It is built
+around the `Database` object that can be obtained using `SQLite3JS.openAsync()`.
+The API was inspired by [node-sqlite3][1].
 
-### JavaScript Example
+ [1]: https://github.com/developmentseed/node-sqlite3/
 
-    dbPath = Windows.Storage.ApplicationData.current.localFolder.path + '\\db.sqlite';
-    db = new SQLite3.Database(dbPath);
+### Example
 
-    statement = db.prepare('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)');
-    statement.step();
-    statement.close();
+    var dbPath = Windows.Storage.ApplicationData.current.localFolder.path + '\\db.sqlite';
+    SQLite3JS.openAsync(dbPath)
+      .then(function (db) {
+        return db.runAsync('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)');
+      })
+      .then(function (db) {
+        return db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Mango', 4.6, 123]);
+      })
+      .then(function (db) {
+        return db.eachAsync('SELECT * FROM Item', function (row) {
+          console.log('Get a ' + row.name + ' for $' + row.price);
+        });
+      })
+      .then(function (db) {
+        db.close();
+      });
 
-    statement = db.prepare('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)');
-    statement.bindText(1, 'Mango');
-    statement.bindDouble(2, 4.6);
-    statement.bindInt(3, 123);
-    statement.step();
-    statement.close();
+## SQLite3 WinRT Component
 
-    statement = db.prepare('SELECT * FROM Item');
-    while (statement.step() === SQLite3.ResultCode.row) {
-      name = statement.columnText(0);
-      price = statement.columnDouble(1);
-      id = statement.columnInt(2);
-    }
-    statement.close();
-
-    db.close();
-
-## _SQLite3JS_
-
-This abstraction layer on top of the _SQLite3_ component facilitates using
-SQLite in JavaScript applications.
-
-### JavaScript Example
-
-    dbPath = Windows.Storage.ApplicationData.current.localFolder.path + '\\db.sqlite';
-    db = new SQLite3JS.Database(dbPath);
-
-    db.run('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)');
-    db.run('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Mango', 4.6, 123]);
-
-    rows = db.all('SELECT * FROM Item');
-    rows.forEach(function (row) {
-      name = row.name;
-      price = row.price;
-      id = row.id;
-    });
-
-    db.close();
+In addition to the JavaScript API, SQLite3-WinRT contains a WinRT component DLL
+called SQLite3. This component is the basis for SQLite3JS, but it can also be
+used directly, e.g. in a C# app.
 
 ## License
 

--- a/SQLite3/Common.h
+++ b/SQLite3/Common.h
@@ -7,7 +7,8 @@ namespace SQLite3 {
 
   typedef Windows::Foundation::Collections::IKeyValuePair<Platform::String^, Platform::Object^> Parameter;
   typedef Windows::Foundation::Collections::IVectorView<Platform::Object^> Parameters;
-  typedef Windows::Foundation::Collections::PropertySet Row;
+  typedef Windows::Foundation::Collections::IMapView<Platform::String^, Platform::Object^> Row;
+  typedef Windows::Foundation::Collections::IVectorView<Row^> Rows;
 
   using Windows::Foundation::IAsyncAction;
   using Windows::Foundation::IAsyncOperation;

--- a/SQLite3/Common.h
+++ b/SQLite3/Common.h
@@ -1,5 +1,14 @@
 #pragma once;
 
 namespace SQLite3 {
+  ref class Database;
+  class Statement;
+  typedef std::unique_ptr<Statement> StatementPtr;
+
+  typedef Windows::Foundation::Collections::IKeyValuePair<Platform::String^, Platform::Object^> Parameter;
+  typedef Windows::Foundation::Collections::IVectorView<Platform::Object^> Parameters;
+  typedef Windows::Foundation::Collections::PropertySet Row;
+
+  using Windows::Foundation::IAsyncAction;
   using Windows::Foundation::IAsyncOperation;
 }

--- a/SQLite3/Common.h
+++ b/SQLite3/Common.h
@@ -5,8 +5,9 @@ namespace SQLite3 {
   class Statement;
   typedef std::unique_ptr<Statement> StatementPtr;
 
-  typedef Windows::Foundation::Collections::IKeyValuePair<Platform::String^, Platform::Object^> Parameter;
   typedef Windows::Foundation::Collections::IVectorView<Platform::Object^> Parameters;
+  typedef std::vector<Platform::Object^> SafeParameters;
+
   typedef Windows::Foundation::Collections::IMapView<Platform::String^, Platform::Object^> Row;
   typedef Windows::Foundation::Collections::IVectorView<Row^> Rows;
 

--- a/SQLite3/Common.h
+++ b/SQLite3/Common.h
@@ -1,0 +1,5 @@
+#pragma once;
+
+namespace SQLite3 {
+  using Windows::Foundation::IAsyncOperation;
+}

--- a/SQLite3/Common.h
+++ b/SQLite3/Common.h
@@ -11,6 +11,8 @@ namespace SQLite3 {
   typedef Windows::Foundation::Collections::IMapView<Platform::String^, Platform::Object^> Row;
   typedef Windows::Foundation::Collections::IVectorView<Row^> Rows;
 
+  public delegate void EachCallback(Row^);
+
   using Windows::Foundation::IAsyncAction;
   using Windows::Foundation::IAsyncOperation;
 }

--- a/SQLite3/Constants.h
+++ b/SQLite3/Constants.h
@@ -2,10 +2,8 @@
 
 #include "sqlite3.h"
 
-namespace SQLite3
-{
-  public ref class Datatype sealed
-  {
+namespace SQLite3 {
+  public ref class Datatype sealed {
   public:
     static property int Integer { int get() { return SQLITE_INTEGER; } }
     static property int Float { int get() { return SQLITE_FLOAT; } }
@@ -14,8 +12,7 @@ namespace SQLite3
     static property int Null { int get() { return SQLITE_NULL; } }
   };
 
-  public ref class ResultCode sealed
-  {
+  public ref class ResultCode sealed {
   public:
     static property int Ok { int get() { return SQLITE_OK; } }
     static property int Error { int get() { return SQLITE_ERROR; } }

--- a/SQLite3/Database.cpp
+++ b/SQLite3/Database.cpp
@@ -67,9 +67,21 @@ namespace SQLite3 {
     });
   }
 
+  IAsyncAction^ Database::EachAsync(Platform::String^ sql, Parameters^ params, EachCallback^ callback) {
+    auto safeParams = copyParameters(params);
+
+    auto window = Windows::UI::Core::CoreWindow::GetForCurrentThread();
+    auto dispatcher = window->Dispatcher;
+
+    return concurrency::create_async([=]() {
+      StatementPtr statement = PrepareAndBind(sql, safeParams);
+      return statement->Each(callback, dispatcher);
+    });
+  }
+
   StatementPtr Database::PrepareAndBind(Platform::String^ sql, const SafeParameters& params) {
-      StatementPtr statement = Statement::Prepare(sqlite, sql);
-      statement->Bind(params);
-      return statement;
+    StatementPtr statement = Statement::Prepare(sqlite, sql);
+    statement->Bind(params);
+    return statement;
   }
 }

--- a/SQLite3/Database.cpp
+++ b/SQLite3/Database.cpp
@@ -43,6 +43,13 @@ namespace SQLite3 {
     });
   }
 
+  IAsyncOperation<Rows^>^ Database::AllAsync(Platform::String^ sql, Parameters^ params) {
+    return concurrency::create_async([=]() {
+      StatementPtr statement = PrepareAndBind(sql, params);
+      return statement->All();
+    });
+  }
+
   StatementPtr Database::PrepareAndBind(Platform::String^ sql, Parameters^ params) {
     StatementPtr statement = Statement::Prepare(sqlite, sql);
 

--- a/SQLite3/Database.cpp
+++ b/SQLite3/Database.cpp
@@ -29,7 +29,7 @@ namespace SQLite3 {
     sqlite3_close(sqlite);
   }
 
-  Statement^ Database::Prepare(Platform::String^ sql) {
-    return ref new Statement(this, sql);
+  IAsyncOperation<Statement^>^ Database::PrepareAsync(Platform::String^ sql) {
+    return Statement::PrepareAsync(this, sql);
   }
 }

--- a/SQLite3/Database.cpp
+++ b/SQLite3/Database.cpp
@@ -4,15 +4,13 @@
 #include "Database.h"
 #include "Statement.h"
 
-namespace SQLite3
-{
+namespace SQLite3 {
   IAsyncOperation<Database^>^ Database::OpenAsync(Platform::String^ dbPath) {
     return concurrency::create_async([dbPath]() {
       sqlite3* sqlite;
       int ret = sqlite3_open16(dbPath->Data(), &sqlite);
 
-      if (ret != SQLITE_OK)
-      {
+      if (ret != SQLITE_OK) {
         sqlite3_close(sqlite);
 
         HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
@@ -24,17 +22,14 @@ namespace SQLite3
   }
 
   Database::Database(sqlite3* sqlite)
-    : sqlite(sqlite)
-  {
+    : sqlite(sqlite) {
   }
 
-  Database::~Database()
-  {
+  Database::~Database() {
     sqlite3_close(sqlite);
   }
 
-  Statement^ Database::Prepare(Platform::String^ sql)
-  {
+  Statement^ Database::Prepare(Platform::String^ sql) {
     return ref new Statement(this, sql);
   }
 }

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "sqlite3.h"
+#include "Common.h"
 
 namespace SQLite3 {
   ref class Statement;
-
-  using Windows::Foundation::IAsyncOperation;
 
   public ref class Database sealed {
   public:
@@ -13,7 +12,7 @@ namespace SQLite3 {
 
     ~Database();
 
-    Statement^ Prepare(Platform::String^ sql);
+    IAsyncOperation<Statement^>^ PrepareAsync(Platform::String^ sql);
 
   private:
     friend Statement;

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -2,14 +2,12 @@
 
 #include "sqlite3.h"
 
-namespace SQLite3
-{
+namespace SQLite3 {
   ref class Statement;
 
   using Windows::Foundation::IAsyncOperation;
 
-  public ref class Database sealed
-  {
+  public ref class Database sealed {
   public:
     static IAsyncOperation<Database^>^ OpenAsync(Platform::String^ dbPath);
 

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -15,7 +15,7 @@ namespace SQLite3 {
 
   private:
     Database(sqlite3* sqlite);
-    StatementPtr PrepareAndBind(Platform::String^ sql, Parameters^ params);
+    StatementPtr PrepareAndBind(Platform::String^ sql, const SafeParameters& params);
 
     sqlite3* sqlite;
   };

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -4,20 +4,17 @@
 #include "Common.h"
 
 namespace SQLite3 {
-  ref class Statement;
-
   public ref class Database sealed {
   public:
     static IAsyncOperation<Database^>^ OpenAsync(Platform::String^ dbPath);
-
     ~Database();
 
-    IAsyncOperation<Statement^>^ PrepareAsync(Platform::String^ sql);
+    IAsyncAction^ RunAsync(Platform::String^ sql, Parameters^ params);
+    IAsyncOperation<Row^>^ OneAsync(Platform::String^ sql, Parameters^ params);
 
   private:
-    friend Statement;
-
     Database(sqlite3* sqlite);
+    StatementPtr PrepareAndBind(Platform::String^ sql, Parameters^ params);
 
     sqlite3* sqlite;
   };

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -12,6 +12,7 @@ namespace SQLite3 {
     IAsyncAction^ RunAsync(Platform::String^ sql, Parameters^ params);
     IAsyncOperation<Row^>^ OneAsync(Platform::String^ sql, Parameters^ params);
     IAsyncOperation<Rows^>^ AllAsync(Platform::String^ sql, Parameters^ params);
+    IAsyncAction^ EachAsync(Platform::String^ sql, Parameters^ params, EachCallback^ callback);
 
   private:
     Database(sqlite3* sqlite);

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -11,6 +11,7 @@ namespace SQLite3 {
 
     IAsyncAction^ RunAsync(Platform::String^ sql, Parameters^ params);
     IAsyncOperation<Row^>^ OneAsync(Platform::String^ sql, Parameters^ params);
+    IAsyncOperation<Rows^>^ AllAsync(Platform::String^ sql, Parameters^ params);
 
   private:
     Database(sqlite3* sqlite);

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -6,16 +6,21 @@ namespace SQLite3
 {
   ref class Statement;
 
+  using Windows::Foundation::IAsyncOperation;
+
   public ref class Database sealed
   {
   public:
-    Database(Platform::String^ dbPath);
+    static IAsyncOperation<Database^>^ OpenAsync(Platform::String^ dbPath);
+
     ~Database();
 
     Statement^ Prepare(Platform::String^ sql);
 
   private:
     friend Statement;
+
+    Database(sqlite3* sqlite);
 
     sqlite3* sqlite;
   };

--- a/SQLite3/SQLite3.vcxproj
+++ b/SQLite3/SQLite3.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="Statement.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Common.h" />
     <ClInclude Include="Constants.h" />
     <ClInclude Include="Database.h" />
     <ClInclude Include="sqlite3.h" />

--- a/SQLite3/SQLite3.vcxproj.filters
+++ b/SQLite3/SQLite3.vcxproj.filters
@@ -17,5 +17,6 @@
     <ClInclude Include="Database.h" />
     <ClInclude Include="sqlite3.h" />
     <ClInclude Include="Statement.h" />
+    <ClInclude Include="Common.h" />
   </ItemGroup>
 </Project>

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -54,8 +54,7 @@ namespace SQLite3 {
   }
 
   Row^ Statement::One() {
-    Step();
-    return GetRow();
+    return (Step() == SQLITE_ROW) ? GetRow() : nullptr;
   }
 
   Rows^ Statement::All() {

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -79,6 +79,18 @@ namespace SQLite3 {
     return rows->GetView();
   }
 
+  void Statement::Each(EachCallback^ callback, Windows::UI::Core::CoreDispatcher^ dispatcher) {
+    auto callbackDelegate = ref new Windows::UI::Core::DispatchedHandler([=]() {
+      callback(GetRow());
+    });
+
+    while (Step() == SQLITE_ROW) {
+      auto callbackTask = concurrency::create_task(
+        dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, callbackDelegate));
+      callbackTask.get();
+    }
+  }
+
   Row^ Statement::GetRow() {
     auto row = ref new Platform::Collections::Map<Platform::String^, Platform::Object^>();
 

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -32,14 +32,17 @@ namespace SQLite3 {
     int index = 1;
 
     std::for_each(std::begin(params), std::end(params), [&](Platform::Object^ param) {
-      int ret = SQLITE_ERROR;
-      switch (Platform::Type::GetTypeCode(param->GetType())) {
-      case Platform::TypeCode::Double:
-        ret = sqlite3_bind_double(statement, index, static_cast<double>(param));
-        break;
-      case Platform::TypeCode::String:
-        ret = sqlite3_bind_text16(statement, index, static_cast<Platform::String^>(param)->Data(), -1, SQLITE_TRANSIENT);
-        break;
+      if (param == nullptr) {
+        sqlite3_bind_null(statement, index);
+      } else {
+        switch (Platform::Type::GetTypeCode(param->GetType())) {
+        case Platform::TypeCode::Double:
+          sqlite3_bind_double(statement, index, static_cast<double>(param));
+          break;
+        case Platform::TypeCode::String:
+          sqlite3_bind_text16(statement, index, static_cast<Platform::String^>(param)->Data(), -1, SQLITE_TRANSIENT);
+          break;
+        }
       }
 
       ++index;

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -3,14 +3,11 @@
 #include "Statement.h"
 #include "Database.h"
 
-namespace SQLite3
-{
-  Statement::Statement(Database^ database, Platform::String^ sql)
-  {
+namespace SQLite3 {
+  Statement::Statement(Database^ database, Platform::String^ sql) {
     int ret = sqlite3_prepare16(database->sqlite, sql->Data(), -1, &statement, 0);
 
-    if (ret != SQLITE_OK)
-    {
+    if (ret != SQLITE_OK) {
       sqlite3_finalize(statement);
 
       HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
@@ -18,63 +15,51 @@ namespace SQLite3
     }
   }
 
-  Statement::~Statement()
-  {
+  Statement::~Statement() {
     sqlite3_finalize(statement);
   }
 
-  int Statement::Step()
-  {
+  int Statement::Step() {
     return sqlite3_step(statement);
   }
 
-  int Statement::ColumnCount()
-  {
+  int Statement::ColumnCount() {
     return sqlite3_column_count(statement);
   }
 
-  int Statement::ColumnType(int index)
-  {
+  int Statement::ColumnType(int index) {
     return sqlite3_column_type(statement, index);
   }
 
-  Platform::String^ Statement::ColumnName(int index)
-  {
+  Platform::String^ Statement::ColumnName(int index) {
     return ref new Platform::String(static_cast<const wchar_t*>(sqlite3_column_name16(statement, index)));
   }
 
-  Platform::String^ Statement::ColumnText(int index)
-  {
+  Platform::String^ Statement::ColumnText(int index) {
     return ref new Platform::String(static_cast<const wchar_t*>(sqlite3_column_text16(statement, index)));
   }
 
-  int Statement::ColumnInt(int index)
-  {
+  int Statement::ColumnInt(int index) {
     return sqlite3_column_int(statement, index);
   }
 
-  double Statement::ColumnDouble(int index)
-  {
+  double Statement::ColumnDouble(int index) {
     return sqlite3_column_double(statement, index);
   }
 
-  int Statement::BindText(int index, Platform::String^ val)
-  {
+  int Statement::BindText(int index, Platform::String^ val) {
     return sqlite3_bind_text16(statement, index, val->Data(), -1, SQLITE_TRANSIENT);
   }
 
-  int Statement::BindInt(int index, int val)
-  {
+  int Statement::BindInt(int index, int val) {
     return sqlite3_bind_int(statement, index, val);
   }
 
-  int Statement::BindDouble(int index, double val)
-  {
+  int Statement::BindDouble(int index, double val) {
     return sqlite3_bind_double(statement, index, val);
   }
 
-  int Statement::BindNull(int index)
-  {
+  int Statement::BindNull(int index) {
     return sqlite3_bind_null(statement, index);
   }
 }

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -50,23 +50,12 @@ namespace SQLite3 {
   }
 
   void Statement::Run() {
-    int ret = Step();
-
-    if (ret != SQLITE_ROW && ret != SQLITE_DONE) {
-      HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
-      throw ref new Platform::COMException(hresult);
-    }
+    Step();
   }
 
   Row^ Statement::One() {
-    int ret = Step();
-
-    if (ret == SQLITE_ROW) {
-      return GetRow();
-    } else {
-      HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
-      throw ref new Platform::COMException(hresult);
-    }
+    Step();
+    return GetRow();
   }
 
   Rows^ Statement::All() {
@@ -119,7 +108,14 @@ namespace SQLite3 {
   }
 
   int Statement::Step() {
-    return sqlite3_step(statement);
+    int ret = sqlite3_step(statement);
+
+    if (ret != SQLITE_ROW && ret != SQLITE_DONE) {
+      HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
+      throw ref new Platform::COMException(hresult);
+    }
+
+    return ret;
   }
 
   int Statement::ColumnCount() {

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -1,3 +1,4 @@
+#include <collection.h>
 #include <ppltasks.h>
 #include <Winerror.h>
 
@@ -66,8 +67,18 @@ namespace SQLite3 {
     }
   }
 
+  Rows^ Statement::All() {
+    auto rows = ref new Platform::Collections::Vector<Row^>();
+
+    while (Step() == SQLITE_ROW) {
+      rows->Append(GetRow());
+    }
+
+    return rows->GetView();
+  }
+
   Row^ Statement::GetRow() {
-    Row^ row = ref new Row();
+    auto row = ref new Platform::Collections::Map<Platform::String^, Platform::Object^>();
 
     int columnCount = ColumnCount();
     for (int i = 0 ; i < columnCount; ++i) {
@@ -75,7 +86,7 @@ namespace SQLite3 {
       row->Insert(name, GetColumn(i));
     }
 
-    return row;
+    return row->GetView();
   }
 
   Platform::Object^ Statement::GetColumn(int index) {

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -5,20 +5,18 @@
 #include "Database.h"
 
 namespace SQLite3 {
-  IAsyncOperation<Statement^>^ Statement::PrepareAsync(Database^ database, Platform::String^ sql) {
-    return concurrency::create_async([database, sql]() {
-      sqlite3_stmt* statement;
-      int ret = sqlite3_prepare16(database->sqlite, sql->Data(), -1, &statement, 0);
+  StatementPtr Statement::Prepare(sqlite3* sqlite, Platform::String^ sql) {
+    sqlite3_stmt* statement;
+    int ret = sqlite3_prepare16(sqlite, sql->Data(), -1, &statement, 0);
 
-      if (ret != SQLITE_OK) {
-        sqlite3_finalize(statement);
+    if (ret != SQLITE_OK) {
+      sqlite3_finalize(statement);
 
-        HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
-        throw ref new Platform::COMException(hresult);
-      }
+      HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
+      throw ref new Platform::COMException(hresult);
+    }
 
-      return ref new Statement(statement);
-    });
+    return StatementPtr(new Statement(statement));
   }
 
   Statement::Statement(sqlite3_stmt* statement)
@@ -27,6 +25,72 @@ namespace SQLite3 {
 
   Statement::~Statement() {
     sqlite3_finalize(statement);
+  }
+
+  void Statement::Bind(Parameters^ params) {
+    auto iter = params->First();
+    int index = 1;
+    do {
+      auto param = iter->Current;
+      int ret = SQLITE_ERROR;
+      switch (Platform::Type::GetTypeCode(param->GetType())) {
+      case Platform::TypeCode::Double:
+        ret = sqlite3_bind_double(statement, index, static_cast<double>(param));
+        break;
+      case Platform::TypeCode::String:
+        ret = sqlite3_bind_text16(statement, index, static_cast<Platform::String^>(param)->Data(), -1, SQLITE_TRANSIENT);
+        break;
+      }
+
+      ++index;
+    } while (iter->MoveNext());
+  }
+
+  void Statement::Run() {
+    int ret = Step();
+
+    if (ret != SQLITE_ROW && ret != SQLITE_DONE) {
+      HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
+      throw ref new Platform::COMException(hresult);
+    }
+  }
+
+  Row^ Statement::One() {
+    int ret = Step();
+
+    if (ret == SQLITE_ROW) {
+      return GetRow();
+    } else {
+      HRESULT hresult = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_ITF, ret);
+      throw ref new Platform::COMException(hresult);
+    }
+  }
+
+  Row^ Statement::GetRow() {
+    Row^ row = ref new Row();
+
+    int columnCount = ColumnCount();
+    for (int i = 0 ; i < columnCount; ++i) {
+      auto name = ColumnName(i);
+      row->Insert(name, GetColumn(i));
+    }
+
+    return row;
+  }
+
+  Platform::Object^ Statement::GetColumn(int index) {
+    switch (ColumnType(index)) {
+    case SQLITE_INTEGER:
+      return ColumnInt(index);
+    case SQLITE_FLOAT:
+      return ColumnDouble(index);
+    case SQLITE_TEXT:
+      return ColumnText(index);
+    case SQLITE_NULL:
+      return nullptr;
+    default:
+      throw ref new Platform::FailureException();
+    }
   }
 
   int Statement::Step() {

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -28,11 +28,10 @@ namespace SQLite3 {
     sqlite3_finalize(statement);
   }
 
-  void Statement::Bind(Parameters^ params) {
-    auto iter = params->First();
+  void Statement::Bind(const SafeParameters& params) {
     int index = 1;
-    do {
-      auto param = iter->Current;
+
+    std::for_each(std::begin(params), std::end(params), [&](Platform::Object^ param) {
       int ret = SQLITE_ERROR;
       switch (Platform::Type::GetTypeCode(param->GetType())) {
       case Platform::TypeCode::Double:
@@ -44,7 +43,7 @@ namespace SQLite3 {
       }
 
       ++index;
-    } while (iter->MoveNext());
+    });
   }
 
   void Statement::Run() {

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -9,7 +9,7 @@ namespace SQLite3 {
     static StatementPtr Prepare(sqlite3* sqlite, Platform::String^ sql);
     ~Statement();
 
-    void Bind(Parameters^ params);
+    void Bind(const SafeParameters& params);
     void Run();
     Row^ One();
     Rows^ All();

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -12,6 +12,7 @@ namespace SQLite3 {
     void Bind(Parameters^ params);
     void Run();
     Row^ One();
+    Rows^ All();
 
   private:
     Statement(sqlite3_stmt* statement);

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -13,6 +13,7 @@ namespace SQLite3 {
     void Run();
     Row^ One();
     Rows^ All();
+    void Each(EachCallback^ callback, Windows::UI::Core::CoreDispatcher^ dispatcher);
 
   private:
     Statement(sqlite3_stmt* statement);

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -2,12 +2,10 @@
 
 #include "sqlite3.h"
 
-namespace SQLite3
-{
+namespace SQLite3 {
   ref class Database;
 
-  public ref class Statement sealed
-  {
+  public ref class Statement sealed {
   public:
     Statement(Database^ database, Platform::String^ sql);
     ~Statement();

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "sqlite3.h"
+#include "Common.h"
 
 namespace SQLite3 {
   ref class Database;
 
   public ref class Statement sealed {
   public:
-    Statement(Database^ database, Platform::String^ sql);
+    static IAsyncOperation<Statement^>^ PrepareAsync(Database^ database, Platform::String^ sql);
+
     ~Statement();
 
     int Step();
@@ -26,6 +28,8 @@ namespace SQLite3 {
     int BindNull(int index);
 
   private:
+    Statement(sqlite3_stmt* statement);
+
     sqlite3_stmt* statement;
   };
 }

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -4,13 +4,20 @@
 #include "Common.h"
 
 namespace SQLite3 {
-  ref class Database;
-
-  public ref class Statement sealed {
+  class Statement {
   public:
-    static IAsyncOperation<Statement^>^ PrepareAsync(Database^ database, Platform::String^ sql);
-
+    static StatementPtr Prepare(sqlite3* sqlite, Platform::String^ sql);
     ~Statement();
+
+    void Bind(Parameters^ params);
+    void Run();
+    Row^ One();
+
+  private:
+    Statement(sqlite3_stmt* statement);
+
+    Row^ GetRow();
+    Platform::Object^ GetColumn(int index);
 
     int Step();
 
@@ -28,8 +35,6 @@ namespace SQLite3 {
     int BindNull(int index);
 
   private:
-    Statement(sqlite3_stmt* statement);
-
     sqlite3_stmt* statement;
   };
 }

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -3,10 +3,11 @@
 
   var Database, ItemDataSource, GroupDataSource;
 
-  function toSQLiteError(comException, message) {
-    var error = new Error(message);
-    error.resultCode = comException.number & 0xffff;
-    return error;
+  function wrapComException(comException) {
+    return WinJS.Promise.wrapError({
+      message: 'SQLite Error',
+      resultCode: comException.number & 0xffff
+    });
   }
 
   Database = WinJS.Class.define(function (connection) {
@@ -14,23 +15,17 @@
   }, {
     runAsync: function (sql, args) {
       return this.connection.runAsync(sql, args).then(function () {
-      }, function (error) {
-        return WinJS.Promise.wrapError(toSQLiteError(error));
-      });
+      }, wrapComException);
     },
     oneAsync: function (sql, args) {
       return this.connection.oneAsync(sql, args).then(function (row) {
         return row;
-      }, function (error) {
-        return WinJS.Promise.wrapError(toSQLiteError(error));
-      });
+      }, wrapComException);
     },
     allAsync: function (sql, args) {
       return this.connection.allAsync(sql, args).then(function (rows) {
         return rows;
-      }, function (error) {
-        return WinJS.Promise.wrapError(toSQLiteError(error));
-      });
+      }, wrapComException);
     },
     eachAsync: function (sql, args, callback) {
       if (!callback && typeof args === 'function') {
@@ -39,9 +34,7 @@
       }
 
       return this.connection.eachAsync(sql, args, callback).then(function () {
-      }, function (error) {
-        return WinJS.Promise.wrapError(toSQLiteError(error));
-      });
+      }, wrapComException);
     },
     mapAsync: function (sql, args, callback) {
       if (!callback && typeof args === 'function') {
@@ -175,10 +168,7 @@
   function openAsync(dbPath) {
     return SQLite3.Database.openAsync(dbPath).then(function (connection) {
       return new Database(connection);
-    }, function (error) {
-      var sqliteError = toSQLiteError(error, 'Error creating an SQLite database connection.');
-      return WinJS.Promise.wrapError(sqliteError);
-    });
+    }, wrapComException);
   }
 
   WinJS.Namespace.define('SQLite3JS', {

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -10,68 +10,72 @@
     });
   }
 
-  Database = WinJS.Class.define(function (connection) {
-    this.connection = connection;
-  }, {
-    runAsync: function (sql, args) {
-      return this.connection.runAsync(sql, args).then(function () {
-      }, wrapComException);
-    },
-    oneAsync: function (sql, args) {
-      return this.connection.oneAsync(sql, args).then(function (row) {
-        return row;
-      }, wrapComException);
-    },
-    allAsync: function (sql, args) {
-      return this.connection.allAsync(sql, args).then(function (rows) {
-        return rows;
-      }, wrapComException);
-    },
-    eachAsync: function (sql, args, callback) {
-      if (!callback && typeof args === 'function') {
-        callback = args;
-        args = null;
+  function wrapDatabase(connection) {
+    var that = {
+      runAsync: function (sql, args) {
+        return connection.runAsync(sql, args).then(function () {
+          return that;
+        }, wrapComException);
+      },
+      oneAsync: function (sql, args) {
+        return connection.oneAsync(sql, args).then(function (row) {
+          return row;
+        }, wrapComException);
+      },
+      allAsync: function (sql, args) {
+        return connection.allAsync(sql, args).then(function (rows) {
+          return rows;
+        }, wrapComException);
+      },
+      eachAsync: function (sql, args, callback) {
+        if (!callback && typeof args === 'function') {
+          callback = args;
+          args = null;
+        }
+
+        return connection.eachAsync(sql, args, callback).then(function () {
+          return that;
+        }, wrapComException);
+      },
+      mapAsync: function (sql, args, callback) {
+        if (!callback && typeof args === 'function') {
+          callback = args;
+          args = null;
+        }
+
+        var results = [];
+
+        return that.eachAsync(sql, args, function (row) {
+          results.push(callback(row));
+        }).then(function () {
+          return results;
+        });
+      },
+      itemDataSource: function (sql, args, keyColumnName, groupKeyColumnName) {
+        if (typeof args === 'string') {
+          groupKeyColumnName = keyColumnName;
+          keyColumnName = args;
+          args = undefined;
+        }
+
+        return new ItemDataSource(that, sql, args, keyColumnName, groupKeyColumnName);
+      },
+      groupDataSource: function (sql, args, keyColumnName, sizeColumnName) {
+        if (typeof args === 'string') {
+          sizeColumnName = keyColumnName;
+          keyColumnName = args;
+          args = undefined;
+        }
+
+        return new GroupDataSource(that, sql, args, keyColumnName, sizeColumnName);
+      },
+      close: function () {
+        connection.close();
       }
+    };
 
-      return this.connection.eachAsync(sql, args, callback).then(function () {
-      }, wrapComException);
-    },
-    mapAsync: function (sql, args, callback) {
-      if (!callback && typeof args === 'function') {
-        callback = args;
-        args = null;
-      }
-
-      var results = [];
-
-      return this.eachAsync(sql, args, function (row) {
-        results.push(callback(row));
-      }).then(function () {
-        return results;
-      });
-    },
-    itemDataSource: function (sql, args, keyColumnName, groupKeyColumnName) {
-      if (typeof args === 'string') {
-        groupKeyColumnName = keyColumnName;
-        keyColumnName = args;
-        args = undefined;
-      }
-
-      return new ItemDataSource(this, sql, args, keyColumnName, groupKeyColumnName);
-    },
-    groupDataSource: function (sql, args, keyColumnName, sizeColumnName) {
-      if (typeof args === 'string') {
-        sizeColumnName = keyColumnName;
-        keyColumnName = args;
-        args = undefined;
-      }
-
-      return new GroupDataSource(this, sql, args, keyColumnName, sizeColumnName);
-    },
-    close: function () {
-      this.connection.close();
-    }
-  });
+    return that;
+  }
 
   ItemDataSource = WinJS.Class.derive(WinJS.UI.VirtualizedDataSource,
     function (db, sql, args, keyColumnName, groupKeyColumnName) {
@@ -167,7 +171,7 @@
 
   function openAsync(dbPath) {
     return SQLite3.Database.openAsync(dbPath).then(function (connection) {
-      return new Database(connection);
+      return wrapDatabase(connection);
     }, wrapComException);
   }
 

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -138,9 +138,9 @@
         args = null;
       }
 
-      return this.prepareAsync(sql, args).then(function (statement) {
-        statement.each(callback);
-        statement.close();
+      return this.connection.eachAsync(sql, args, callback).then(function () {
+      }, function (error) {
+        return WinJS.Promise.wrapError(toSQLiteError(error));
       });
     },
     mapAsync: function (sql, args, callback) {

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -3,15 +3,6 @@
 
   var Database, ItemDataSource, GroupDataSource;
 
-  // Alternative typeof implementation yielding more meaningful results,
-  // see http://javascriptweblog.wordpress.com/2011/08/08/fixing-the-javascript-typeof-operator/
-  function type(obj) {
-    var typeString;
-
-    typeString = Object.prototype.toString.call(obj);
-    return typeString.substring(8, typeString.length - 1).toLowerCase();
-  }
-
   function toSQLiteError(comException, message) {
     var error = new Error(message);
     error.resultCode = comException.number & 0xffff;
@@ -42,7 +33,7 @@
       });
     },
     eachAsync: function (sql, args, callback) {
-      if (!callback && type(args) === 'function') {
+      if (!callback && typeof args === 'function') {
         callback = args;
         args = null;
       }
@@ -53,7 +44,7 @@
       });
     },
     mapAsync: function (sql, args, callback) {
-      if (!callback && type(args) === 'function') {
+      if (!callback && typeof args === 'function') {
         callback = args;
         args = null;
       }
@@ -67,7 +58,7 @@
       });
     },
     itemDataSource: function (sql, args, keyColumnName, groupKeyColumnName) {
-      if (type(args) === 'string') {
+      if (typeof args === 'string') {
         groupKeyColumnName = keyColumnName;
         keyColumnName = args;
         args = undefined;
@@ -76,7 +67,7 @@
       return new ItemDataSource(this, sql, args, keyColumnName, groupKeyColumnName);
     },
     groupDataSource: function (sql, args, keyColumnName, sizeColumnName) {
-      if (type(args) === 'string') {
+      if (typeof args === 'string') {
         sizeColumnName = keyColumnName;
         keyColumnName = args;
         args = undefined;

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -1,7 +1,7 @@
 ﻿(function () {
   "use strict";
 
-  var Statement, Database, ItemDataSource, GroupDataSource;
+  var Database, ItemDataSource, GroupDataSource;
 
   // Alternative typeof implementation yielding more meaningful results,
   // see http://javascriptweblog.wordpress.com/2011/08/08/fixing-the-javascript-typeof-operator/
@@ -17,97 +17,6 @@
     error.resultCode = comException.number & 0xffff;
     return error;
   }
-
-  Statement = WinJS.Class.define(function (statement, args) {
-    this.statement = statement;
-
-    if (args) {
-      this.bind(args);
-    }
-  }, {
-    bind: function (args) {
-      var index, resultCode;
-
-      args.forEach(function (arg, i) {
-        index = i + 1;
-        switch (type(arg)) {
-          case 'number':
-            if (arg % 1 === 0) {
-              resultCode = this.statement.bindInt(index, arg);
-            } else {
-              resultCode = this.statement.bindDouble(index, arg);
-            }
-            break;
-          case 'string':
-            resultCode = this.statement.bindText(index, arg);
-            break;
-          case 'null':
-            resultCode = this.statement.bindNull(index);
-            break;
-          default:
-            throw new Error("Unsupported argument type: " + type(arg));
-        }
-        if (resultCode !== SQLite3.ResultCode.ok) {
-          throw new Error("Error " + resultCode + " when binding argument to SQL query.");
-        }
-      }, this);
-    },
-    run: function () {
-      this.statement.step();
-    },
-    one: function () {
-      this.statement.step();
-      return this._getRow();
-    },
-    all: function () {
-      var result = [];
-
-      this.each(function (row) {
-        result.push(row);
-      });
-      return result;
-    },
-    each: function (callback) {
-      while (this.statement.step() === SQLite3.ResultCode.row) {
-        callback(this._getRow());
-      }
-    },
-    map: function (callback) {
-      var result = [];
-
-      this.each(function (row) {
-        result.push(callback(row));
-      });
-      return result;
-    },
-    close: function () {
-      this.statement.close();
-    },
-    _getRow: function () {
-      var i, len, name, row = {};
-
-      for (i = 0, len = this.statement.columnCount() ; i < len; i += 1) {
-        name = this.statement.columnName(i);
-        row[name] = this._getColumn(i);
-      }
-
-      return row;
-    },
-    _getColumn: function (index) {
-      switch (this.statement.columnType(index)) {
-        case SQLite3.Datatype.integer:
-          return this.statement.columnInt(index);
-        case SQLite3.Datatype.float:
-          return this.statement.columnDouble(index);
-        case SQLite3.Datatype.text:
-          return this.statement.columnText(index);
-        case SQLite3.Datatype["null"]:
-          return null;
-        default:
-          throw new Error('Unsupported column type in column ' + index);
-      }
-    }
-  });
 
   Database = WinJS.Class.define(function (connection) {
     this.connection = connection;
@@ -155,14 +64,6 @@
         results.push(callback(row));
       }).then(function () {
         return results;
-      });
-    },
-    prepareAsync: function (sql, args) {
-      return this.connection.prepareAsync(sql).then(function (statement) {
-        return new Statement(statement, args);
-      }, function (error) {
-        var sqliteError = toSQLiteError(error, 'Error preparing an SQLite statement.');
-        return WinJS.Promise.wrapError(sqliteError);
       });
     },
     itemDataSource: function (sql, args, keyColumnName, groupKeyColumnName) {

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -149,10 +149,12 @@
         args = null;
       }
 
-      return this.prepareAsync(sql, args).then(function (statement) {
-        var rows = statement.map(callback);
-        statement.close();
-        return rows;
+      var results = [];
+
+      return this.eachAsync(sql, args, function (row) {
+        results.push(callback(row));
+      }).then(function () {
+        return results;
       });
     },
     prepareAsync: function (sql, args) {

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -126,10 +126,10 @@
       });
     },
     allAsync: function (sql, args) {
-      return this.prepareAsync(sql, args).then(function (statement) {
-        var rows = statement.all();
-        statement.close();
+      return this.connection.allAsync(sql, args).then(function (rows) {
         return rows;
+      }, function (error) {
+        return WinJS.Promise.wrapError(toSQLiteError(error));
       });
     },
     eachAsync: function (sql, args, callback) {

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -113,16 +113,16 @@
     this.connection = connection;
   }, {
     runAsync: function (sql, args) {
-      return this.prepareAsync(sql, args).then(function (statement) {
-        statement.run();
-        statement.close();
+      return this.connection.runAsync(sql, args).then(function () {
+      }, function (error) {
+        return WinJS.Promise.wrapError(toSQLiteError(error));
       });
     },
     oneAsync: function (sql, args) {
-      return this.prepareAsync(sql, args).then(function (statement) {
-        var row = statement.one();
-        statement.close();
+      return this.connection.oneAsync(sql, args).then(function (row) {
         return row;
+      }, function (error) {
+        return WinJS.Promise.wrapError(toSQLiteError(error));
       });
     },
     allAsync: function (sql, args) {

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -56,7 +56,7 @@
     );
   });
 
-  xit('should return items with names ending on "e"', function () {
+  it('should return items with names ending on "e"', function () {
     waitsForPromise(
       db.allAsync('SELECT * FROM Item WHERE name LIKE ? ORDER BY id ASC', ['%e'])
         .then(function (rows) {

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -127,7 +127,7 @@
   describe('mapAsync()', function () {
     it('should map a function over all rows', function () {
       waitsForPromise(
-        db.mapAsync('SELECT * FROM Item', function (row) {
+        db.mapAsync('SELECT * FROM Item ORDER BY id', function (row) {
           return row.price > 2 ? 'expensive' : 'cheap';
         }).then(function (rating) {
           expect(rating.length).toEqual(3);
@@ -165,7 +165,7 @@
 
   describe('Item Data Source', function () {
     beforeEach(function () {
-      this.itemDataSource = db.itemDataSource('SELECT * FROM Item', 'id');
+      this.itemDataSource = db.itemDataSource('SELECT * FROM Item ORDER BY id', 'id');
     });
 
     it('should support getCount()', function () {

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -1,5 +1,5 @@
 ﻿describe('SQLite3JS', function () {
-  function waitsForPromise (promise) {
+  function waitsForPromise(promise) {
     var done = false;
 
     promise.then(function () {
@@ -11,7 +11,7 @@
 
     waitsFor(function () { return done; });
   }
-  
+
   var db = null;
 
   beforeEach(function () {
@@ -39,6 +39,18 @@
   });
 
   describe('runAsync()', function () {
+    it('should allow chaining', function () {
+      waitsForPromise(
+        db.runAsync('DELETE FROM Item WHERE id = 1')
+          .then(function (chainedDb) {
+            return chainedDb.oneAsync('SELECT COUNT(*) AS count FROM Item');
+          })
+          .then(function (row) {
+            expect(row.count).toEqual(2);
+          })
+      );
+    });
+
     it('should allow binding null arguments', function () {
       var name = 'Mango';
 

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -67,7 +67,7 @@
     );
   });
 
-  xit('should allow binding null arguments', function () {
+  it('should allow binding null arguments', function () {
     var name = 'Mango';
 
     waitsForPromise(

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -95,6 +95,14 @@
           })
       );
     });
+
+    it('should return empty array for empty queries', function () {
+      waitsForPromise(
+        db.allAsync('SELECT * FROM Item WHERE id < 0').then(function (rows) {
+          expect(rows.length).toEqual(0);
+        })
+      );
+    });
   });
 
   describe('eachAsync()', function () {

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -100,7 +100,7 @@
     );
   });
 
-  xit('should map a function over all rows', function () {
+  it('should map a function over all rows', function () {
     waitsForPromise(
       db.mapAsync('SELECT * FROM Item', function (row) {
         return row.price > 2 ? 'expensive' : 'cheap';

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -137,7 +137,7 @@
     });
   });
 
-  xdescribe('Item Data Source', function () {
+  describe('Item Data Source', function () {
     beforeEach(function () {
       this.itemDataSource = db.itemDataSource('SELECT * FROM Item', 'id');
     });
@@ -160,7 +160,7 @@
     });
   });
 
-  xdescribe('Group Data Source', function () {
+  describe('Group Data Source', function () {
     beforeEach(function () {
       this.groupDataSource = db.groupDataSource(
         'SELECT LENGTH(name) AS key, COUNT(*) AS groupSize FROM Item GROUP BY key',

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -18,91 +18,102 @@
     waitsForPromise(
       SQLite3JS.openAsync(':memory:').then(function (newDb) {
         db = newDb;
-        db.run('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)');
-        db.run('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Apple', 1.2, 1]);
-        db.run('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Orange', 2.5, 2]);
-        db.run('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Banana', 3, 3]);
+        return db.runAsync('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)').then(function () {
+          var promises = [
+            db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Apple', 1.2, 1]),
+            db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Orange', 2.5, 2]),
+            db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Banana', 3, 3])
+          ];
+          return WinJS.Promise.join(promises);
+        });
       })
     );
   });
 
   afterEach(function () {
-    db.run('DROP TABLE Item');
-    db.close();
+    waitsForPromise(
+      db.runAsync('DROP TABLE Item').then(function () {
+        db.close();
+      })
+    );
   });
 
   it('should return the correct count', function () {
-    var row;
-
-    row = db.one('SELECT COUNT(*) AS count FROM Item');
-    return expect(row.count).toEqual(3);
+    waitsForPromise(
+      db.oneAsync('SELECT COUNT(*) AS count FROM Item').then(function (row) {
+        expect(row.count).toEqual(3);
+      })
+    );
   });
 
   it('should return an item by id', function () {
-    var row;
-
-    row = db.one('SELECT * FROM Item WHERE id = ?', [2]);
-    expect(row.name).toEqual('Orange');
-    expect(row.price).toEqual(2.5);
-    expect(row.id).toEqual(2);
+    waitsForPromise(
+      db.oneAsync('SELECT * FROM Item WHERE id = ?', [2]).then(function (row) {
+        expect(row.name).toEqual('Orange');
+        expect(row.price).toEqual(2.5);
+        expect(row.id).toEqual(2);
+      })
+    );
   });
 
   it('should return items with names ending on "e"', function () {
-    var expectedValues, i, properties, property, rows, _i, _len, _ref;
-
-    rows = db.all('SELECT * FROM Item WHERE name LIKE ? ORDER BY id ASC', ['%e']);
-    expect(rows.length).toEqual(2);
-    expect(rows[0].name).toEqual('Apple');
-    expect(rows[1].name).toEqual('Orange');
+    waitsForPromise(
+      db.allAsync('SELECT * FROM Item WHERE name LIKE ? ORDER BY id ASC', ['%e'])
+        .then(function (rows) {
+          expect(rows.length).toEqual(2);
+          expect(rows[0].name).toEqual('Apple');
+          expect(rows[1].name).toEqual('Orange');
+        })
+    );
   });
 
   it('should allow binding null arguments', function () {
-    var row, name = 'Mango';
+    var name = 'Mango';
 
-    db.run('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', [name, null, null]);
-    row = db.one('SELECT * FROM Item WHERE name = ?', [name]);
-    expect(row.name).toEqual(name);
-    expect(row.price).toEqual(null);
-    expect(row.id).toEqual(null);
+    waitsForPromise(
+      db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', [name, null, null])
+        .then(function () {
+          return db.oneAsync('SELECT * FROM Item WHERE name = ?', [name]);
+        })
+        .then(function (row) {
+          expect(row.name).toEqual(name);
+          expect(row.price).toEqual(null);
+          expect(row.id).toEqual(null);
+        })
+    );
   });
 
   it('should call a callback for each row', function () {
-    var calls, countCall = function () { calls += 1; };
+    var calls = 0,
+        countCall = function () { calls += 1; };
 
-    calls = 0;
-    db.each('SELECT * FROM Item', countCall);
-    expect(calls).toEqual(3);
-
-    calls = 0;
-    db.each('SELECT * FROM Item WHERE price > ?', [2], countCall);
-    expect(calls).toEqual(2);
+    waitsForPromise(
+      db.eachAsync('SELECT * FROM Item', countCall)
+        .then(function () {
+          expect(calls).toEqual(3);
+          calls = 0;
+          return db.eachAsync('SELECT * FROM Item WHERE price > ?', [2], countCall);
+        })
+        .then(function () {
+          expect(calls).toEqual(2);
+        })
+    );
   });
 
   it('should map a function over all rows', function () {
-    var rating = db.map('SELECT * FROM Item', function (row) {
-      return row.price > 2 ? 'expensive' : 'cheap';
-    });
-
-    expect(rating.length).toEqual(3);
-    expect(rating[0]).toEqual('cheap');
-    expect(rating[1]).toEqual('expensive');
-    expect(rating[2]).toEqual('expensive');
+    waitsForPromise(
+      db.mapAsync('SELECT * FROM Item', function (row) {
+        return row.price > 2 ? 'expensive' : 'cheap';
+      }).then(function (rating) {
+        expect(rating.length).toEqual(3);
+        expect(rating[0]).toEqual('cheap');
+        expect(rating[1]).toEqual('expensive');
+        expect(rating[2]).toEqual('expensive');
+      })
+    );
   });
 
   describe('Error Handling', function () {
-    beforeEach(function () {
-      this.addMatchers({
-        toThrowWithResultCode: function (expected) {
-          try {
-            this.actual();
-            return false;
-          } catch (error) {
-            return error.resultCode === expected;
-          }
-        }
-      });
-    });
-
     it('should throw when creating an invalid database', function () {
       waitsForPromise(
         SQLite3JS.openAsync('invalid path').then(function (db) {
@@ -115,9 +126,14 @@
     });
 
     it('should throw when executing an invalid statement', function () {
-      expect(function () {
-        db.run('invalid sql');
-      }).toThrowWithResultCode(SQLite3.ResultCode.error);
+      waitsForPromise(
+        db.runAsync('invalid sql').then(function () {
+          // The complete callback isn't supposed to be called.
+          expect(false).toBe(true);
+        }, function (error) {
+          expect(error.resultCode).toEqual(SQLite3.ResultCode.error);
+        })
+      );
     });
   });
 

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -56,7 +56,7 @@
     );
   });
 
-  it('should return items with names ending on "e"', function () {
+  xit('should return items with names ending on "e"', function () {
     waitsForPromise(
       db.allAsync('SELECT * FROM Item WHERE name LIKE ? ORDER BY id ASC', ['%e'])
         .then(function (rows) {
@@ -67,7 +67,7 @@
     );
   });
 
-  it('should allow binding null arguments', function () {
+  xit('should allow binding null arguments', function () {
     var name = 'Mango';
 
     waitsForPromise(
@@ -83,7 +83,7 @@
     );
   });
 
-  it('should call a callback for each row', function () {
+  xit('should call a callback for each row', function () {
     var calls = 0,
         countCall = function () { calls += 1; };
 
@@ -100,7 +100,7 @@
     );
   });
 
-  it('should map a function over all rows', function () {
+  xit('should map a function over all rows', function () {
     waitsForPromise(
       db.mapAsync('SELECT * FROM Item', function (row) {
         return row.price > 2 ? 'expensive' : 'cheap';
@@ -137,7 +137,7 @@
     });
   });
 
-  describe('Item Data Source', function () {
+  xdescribe('Item Data Source', function () {
     beforeEach(function () {
       this.itemDataSource = db.itemDataSource('SELECT * FROM Item', 'id');
     });
@@ -160,7 +160,7 @@
     });
   });
 
-  describe('Group Data Source', function () {
+  xdescribe('Group Data Source', function () {
     beforeEach(function () {
       this.groupDataSource = db.groupDataSource(
         'SELECT LENGTH(name) AS key, COUNT(*) AS groupSize FROM Item GROUP BY key',

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -83,7 +83,7 @@
     );
   });
 
-  xit('should call a callback for each row', function () {
+  it('should call a callback for each row', function () {
     var calls = 0,
         countCall = function () { calls += 1; };
 

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -67,6 +67,16 @@
     );
   });
 
+  describe('oneAsync()', function () {
+    it('should return null for empty queries', function () {
+      waitsForPromise(
+        db.oneAsync('SELECT * FROM Item WHERE name = ?', ['BEEF']).then(function (row) {
+          expect(row).toBeNull();
+        })
+      );
+    });
+  });
+
   it('should allow binding null arguments', function () {
     var name = 'Mango';
 


### PR DESCRIPTION
Make the whole API async. E.g. instead of `db.run(sql)`, we now use `db.runAsync(sql)` which returns a `WinJS.Promise`. The old synchronous API has been removed. Support for working with statements directly has also been dropped for now.

Closes #7
