### PR TITLE
Support Timestamps and 64bit Integers

### DIFF
--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -28,6 +28,10 @@ namespace SQLite3 {
     sqlite3_finalize(statement);
   }
 
+  static inline uint64 FoundationTimeToUnixCompatible(Windows::Foundation::DateTime foundationTime){
+    return (foundationTime.UniversalTime/10000)-11644473600000;
+  }
+
   void Statement::Bind(const SafeParameters& params) {
     int index = 1;
 
@@ -36,6 +40,9 @@ namespace SQLite3 {
         sqlite3_bind_null(statement, index);
       } else {
         switch (Platform::Type::GetTypeCode(param->GetType())) {
+        case Platform::TypeCode::DateTime:
+          sqlite3_bind_int64(statement, index, FoundationTimeToUnixCompatible(static_cast<Windows::Foundation::DateTime>(param)));
+          break;
         case Platform::TypeCode::Double:
           sqlite3_bind_double(statement, index, static_cast<double>(param));
           break;
@@ -133,8 +140,8 @@ namespace SQLite3 {
     return ref new Platform::String(static_cast<const wchar_t*>(sqlite3_column_text16(statement, index)));
   }
 
-  int Statement::ColumnInt(int index) {
-    return sqlite3_column_int(statement, index);
+  int64 Statement::ColumnInt(int index) {
+    return sqlite3_column_int64(statement, index);
   }
 
   double Statement::ColumnDouble(int index) {

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -28,7 +28,7 @@ namespace SQLite3 {
     Platform::String^ ColumnName(int index);
 
     Platform::String^ ColumnText(int index);
-    int ColumnInt(int index);
+    int64 ColumnInt(int index);
     double ColumnDouble(int index);
 
     int BindText(int index, Platform::String^ val);

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -18,7 +18,7 @@
     waitsForPromise(
       SQLite3JS.openAsync(':memory:').then(function (newDb) {
         db = newDb;
-        return db.runAsync('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)').then(function () {
+        return db.runAsync('CREATE TABLE Item (name TEXT, price REAL, dateBought UNSIGNED BIG INT, id INT PRIMARY KEY)').then(function () {
           var promises = [
             db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Apple', 1.2, 1]),
             db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Orange', 2.5, 2]),
@@ -63,6 +63,22 @@
             expect(row.name).toEqual(name);
             expect(row.price).toEqual(null);
             expect(row.id).toEqual(null);
+          })
+      );
+    });
+
+    it('should support binding javascript date arguments', function () {
+      var name = 'Melon';
+      var dateBought = new Date()
+
+      waitsForPromise(
+        db.runAsync('INSERT INTO Item (name, dateBought) VALUES (?, ?)', [name, dateBought])
+          .then(function () {
+            return db.oneAsync('SELECT * FROM Item WHERE dateBought=?', [dateBought]);
+          })
+          .then(function (row) {
+            expect(row.name).toEqual(name);
+            expect(new Date(row.dateBought)).toEqual(dateBought);
           })
       );
     });


### PR DESCRIPTION
Store dates from Javascript in a unix-epoch friendly manner.

NOTE: Javascript has millisecond precision while a classic unix timestamp only supports seconds. To achieve maximum compatibility between dates stored and retrieved in JavaScript, I opted to store the dates in millisecond-precision. So if you want to do date calculations in your SQL, you have to divide by 1000 and specify the 'unixepoch' modifier.

Example: SELECT DATETIME(my_date_field/1000, 'unixepoch', '+3 days') FROM my_table;
