### PR TITLE
Support Timestamps and 64bit Integers

### DIFF
--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -54,11 +54,18 @@ namespace SQLite3 {
     }
   }
 
+  static inline uint64 FoundationTimeToUnixCompatible(Windows::Foundation::DateTime foundationTime){
+    return (foundationTime.UniversalTime/10000)-11644473600000;
+  }
+
   void Statement::BindParameter(int index, Platform::Object^ value) {
     if (value == nullptr) {
       sqlite3_bind_null(statement, index);
     } else {
       switch (Platform::Type::GetTypeCode(value->GetType())) {
+      case Platform::TypeCode::DateTime:
+        sqlite3_bind_int64(statement, index, FoundationTimeToUnixCompatible(static_cast<Windows::Foundation::DateTime>(value)));
+        break;
       case Platform::TypeCode::Double:
         sqlite3_bind_double(statement, index, static_cast<double>(value));
         break;
@@ -177,8 +184,8 @@ namespace SQLite3 {
     return ref new Platform::String(static_cast<const wchar_t*>(sqlite3_column_text16(statement, index)));
   }
 
-  int Statement::ColumnInt(int index) {
-    return sqlite3_column_int(statement, index);
+  int64 Statement::ColumnInt(int index) {
+    return sqlite3_column_int64(statement, index);
   }
 
   double Statement::ColumnDouble(int index) {

--- a/SQLite3/Statement.cpp
+++ b/SQLite3/Statement.cpp
@@ -62,7 +62,8 @@ namespace SQLite3 {
     if (value == nullptr) {
       sqlite3_bind_null(statement, index);
     } else {
-      switch (Platform::Type::GetTypeCode(value->GetType())) {
+      auto typeCode = Platform::Type::GetTypeCode(value->GetType());
+      switch (typeCode) {
       case Platform::TypeCode::DateTime:
         sqlite3_bind_int64(statement, index, FoundationTimeToUnixCompatible(static_cast<Windows::Foundation::DateTime>(value)));
         break;
@@ -72,6 +73,23 @@ namespace SQLite3 {
       case Platform::TypeCode::String:
         sqlite3_bind_text16(statement, index, static_cast<Platform::String^>(value)->Data(), -1, SQLITE_TRANSIENT);
         break;
+      case Platform::TypeCode::Boolean:
+        sqlite3_bind_int(statement, index, static_cast<Platform::Boolean>(value) ? 1 : 0);
+        break;
+      case Platform::TypeCode::Int8:
+      case Platform::TypeCode::Int16:
+      case Platform::TypeCode::Int32:
+      case Platform::TypeCode::UInt8:
+      case Platform::TypeCode::UInt16:
+      case Platform::TypeCode::UInt32:
+        sqlite3_bind_int(statement, index, static_cast<int>(value));
+        break;
+      case Platform::TypeCode::Int64:
+      case Platform::TypeCode::UInt64:
+        sqlite3_bind_int64(statement, index, static_cast<int64>(value));
+        break;
+      default: 
+        throw ref new Platform::InvalidArgumentException();
       }
     }
   }

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -36,7 +36,7 @@ namespace SQLite3 {
     int ColumnType(int index);
     Platform::String^ ColumnName(int index);
     Platform::String^ ColumnText(int index);
-    int ColumnInt(int index);
+    int64 ColumnInt(int index);
     double ColumnDouble(int index);
 
   private:

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -34,7 +34,7 @@
     waitsForPromise(
       SQLite3JS.openAsync(':memory:').then(function (newDb) {
         db = newDb;
-        return db.runAsync('CREATE TABLE Item (name TEXT, price REAL, id INT PRIMARY KEY)').then(function () {
+        return db.runAsync('CREATE TABLE Item (name TEXT, price REAL, dateBought UNSIGNED BIG INT, id INT PRIMARY KEY)').then(function () {
           var promises = [
             db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Apple', 1.2, 1]),
             db.runAsync('INSERT INTO Item (name, price, id) VALUES (?, ?, ?)', ['Orange', 2.5, 2]),
@@ -79,6 +79,22 @@
             expect(row.name).toEqual(name);
             expect(row.price).toEqual(null);
             expect(row.id).toEqual(null);
+          })
+      );
+    });
+
+    it('should support binding javascript date arguments', function () {
+      var name = 'Melon';
+      var dateBought = new Date()
+
+      waitsForPromise(
+        db.runAsync('INSERT INTO Item (name, dateBought) VALUES (?, ?)', [name, dateBought])
+          .then(function () {
+            return db.oneAsync('SELECT * FROM Item WHERE dateBought=?', [dateBought]);
+          })
+          .then(function (row) {
+            expect(row.name).toEqual(name);
+            expect(new Date(row.dateBought)).toEqual(dateBought);
           })
       );
     });


### PR DESCRIPTION
Store dates from Javascript in a unix-epoch friendly manner.

NOTE: Javascript has millisecond precision while a classic unix timestamp only supports seconds. To achieve maximum compatibility between dates stored and retrieved in JavaScript, I opted to store the dates in millisecond-precision. So if you want to do date calculations in your SQL, you have to divide by 1000 and specify the 'unixepoch' modifier.

Example: SELECT DATETIME(my_date_field/1000, 'unixepoch', '+3 days') FROM my_table;
