### PR TITLE
Performance: use PropertySet iterator for toObjectImpl

### DIFF
--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -12,19 +12,18 @@
     return typeString.substring(8, typeString.length - 1).toLowerCase();
   }
 
-  function toObject(propertySet) {
-    function toObjectImpl(propertySet) {
-      var key, object = {};
+  function toObjectImpl(propertySet) {
+    var key, object = {}, iterator = propertySet.first();
 
-      for (key in propertySet) {
-        if (propertySet.hasOwnProperty(key)) {
-          object[key] = propertySet[key];
-        }
-      }
-
-      return object;
+    while (iterator.hasCurrent) {
+      object[iterator.current.key] = iterator.current.value;
+      iterator.moveNext();
     }
 
+    return object;
+  }
+
+  function toObject(propertySet) {
     return propertySet ? toObjectImpl(propertySet) : null;
   }
 


### PR DESCRIPTION
Since iterating over the JavaScript properties in toObjectImpl took so much time, I replaced it with the IIterator<IKeyValuePair> from PropertySet.
