### PR TITLE
Rowcounter scalar

### DIFF
--- a/SQLite3/Database.cpp
+++ b/SQLite3/Database.cpp
@@ -47,6 +47,7 @@ namespace SQLite3 {
     : sqlite(sqlite)
     , dispatcher(dispatcher) {
       sqlite3_update_hook(sqlite, UpdateHook, reinterpret_cast<void*>(this));
+      sqlite3_create_function(sqlite, "ROWCOUNTER", 0, SQLITE_ANY, reinterpret_cast<void*>(this), &sqlite_row_counter, NULL, NULL);
   }
 
   Database::~Database() {
@@ -170,6 +171,11 @@ namespace SQLite3 {
     });
   }
 
+  void sqlite_row_counter(sqlite3_context* context,int ,sqlite3_value**) {
+    Database^ db = reinterpret_cast<Database^>(sqlite3_user_data(context));
+    sqlite3_result_int64(context, ++db->statementRowCounter);
+  }
+
   bool Database::GetAutocommit() {
     return sqlite3_get_autocommit(sqlite) != 0;
   }
@@ -184,6 +190,7 @@ namespace SQLite3 {
 
   template <typename ParameterContainer>
   StatementPtr Database::PrepareAndBind(Platform::String^ sql, ParameterContainer params) {
+    statementRowCounter = 0;
     StatementPtr statement = Statement::Prepare(sqlite, sql);
     statement->Bind(params);
     return statement;

--- a/SQLite3/Database.h
+++ b/SQLite3/Database.h
@@ -12,6 +12,8 @@ namespace SQLite3 {
   public delegate void ChangeHandler(Platform::Object^ source, ChangeEvent event);
   
   public ref class Database sealed {
+    friend void sqlite_row_counter(sqlite3_context*,int,sqlite3_value**);
+
   public:
     static IAsyncOperation<Database^>^ OpenAsync(Platform::String^ dbPath);
     static void EnableSharedCache(bool enable);
@@ -53,6 +55,7 @@ namespace SQLite3 {
     static void __cdecl UpdateHook(void* data, int action, char const* dbName, char const* tableName, sqlite3_int64 rowId);
     void OnChange(int action, char const* dbName, char const* tableName, sqlite3_int64 rowId);
 
+    sqlite_int64 statementRowCounter;
     Windows::UI::Core::CoreDispatcher^ dispatcher;
     sqlite3* sqlite;
     std::wstring lastErrorMsg;

--- a/SQLite3/Statement.h
+++ b/SQLite3/Statement.h
@@ -5,8 +5,6 @@
 
 namespace SQLite3 {
   class Statement {
-    friend void notifyUnlock(void* args[], int nArgs);
-
   public:
     static StatementPtr Prepare(sqlite3* sqlite, Platform::String^ sql);
     ~Statement();

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -271,6 +271,18 @@
     });
   });
 
+  describe('rowCounter scalar function', function () {
+    it('should support the ROWCOUNTER() scalar function', function () {
+      waitsForPromise(
+        db.allAsync("SELECT * FROM (SELECT name, ROWCOUNTER() as nr FROM Item) WHERE nr > 1").then(function (results) {
+          expect(results.length).toEqual(2);
+          expect(results[0].name).toEqual('Orange');
+          expect(results[1].name).toEqual('Banana');
+        })
+      );
+    });
+  });
+
   describe('Events', function () {
     function expectEvent(eventName, rowId, callback) {
       var calledEventHandler = false;


### PR DESCRIPTION
Introduce a scalar function ROWCOUNTER which will number all rows returned in a select.
We can use this in our data source to find indices for newly inserted or updated items.
