### PR TITLE
Add Debug Mode

### DIFF
--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -1,7 +1,12 @@
 ﻿(function () {
   "use strict";
 
-  var Database, ItemDataSource, GroupDataSource;
+  var SQLite3JS, Database, ItemDataSource, GroupDataSource;
+
+  SQLite3JS = {
+    debug: false,
+    log: console.log.bind(console)
+  };
 
   function PromiseQueue() {
     this._items = [];
@@ -105,6 +110,11 @@
     var that, queue = new PromiseQueue();
 
     function callNativeAsync(funcName, sql, args, callback) {
+      if (SQLite3JS.debug) {
+        var argString = args ? ' ' + args.toString() : '';
+        SQLite3JS.log('Database#' + funcName + ': ' + sql + argString);
+      }
+
       return queue.append(function () {
         var preparedArgs = prepareArgs(args);
         if (preparedArgs instanceof Windows.Foundation.Collections.PropertySet) {
@@ -331,14 +341,11 @@
     }
   );
 
-  function openAsync(dbPath) {
+  SQLite3JS.openAsync = function (dbPath) {
     return SQLite3.Database.openAsync(dbPath).then(function (connection) {
       return wrapDatabase(connection);
     }, wrapException);
-  }
+  };
 
-  WinJS.Namespace.define('SQLite3JS', {
-    openAsync: openAsync
-  });
-
+  WinJS.Namespace.define('SQLite3JS', SQLite3JS);
 }());

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -461,7 +461,7 @@
           white: true,
           nomen: true,
           bitwise: true,
-          predef: ['SQLite3', 'WinJS', 'Windows']
+          predef: ['SQLite3', 'WinJS', 'Windows', 'console']
         };
         if (JSLINT(this.actual, options)) {
           return true;


### PR DESCRIPTION
The debug mode can be enabled by setting `SQLite3JS.debug = true`. Any SQL query issued on a Database object (e.g. using `db.runAsync()`) is then logged using the `SQLite3JS.log` function, which defaults to `console.log`.
