### PR TITLE
Fix SQLite3JS.debug Flag

### DIFF
--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -1,4 +1,4 @@
-﻿(function () {
+﻿var SQLite3JS = (function () {
   "use strict";
 
   var SQLite3JS, Database, ItemDataSource, GroupDataSource;
@@ -347,5 +347,5 @@
     }, wrapException);
   };
 
-  WinJS.Namespace.define('SQLite3JS', SQLite3JS);
+  return SQLite3JS;
 }());


### PR DESCRIPTION
Due to the inner workings of WinJS.Namespace.define(), the debug flag of the
global SQLite3JS namespace was not the same as the flag of the namespace
object inside the IIFE. Fixed by simply defining the global namespace outside
of the IIFE instead of using WinJS.Namespace.define().
