### PR TITLE
Vacuum handling

### DIFF
--- a/SQLite3Component/Database.cpp
+++ b/SQLite3Component/Database.cpp
@@ -75,6 +75,8 @@ namespace SQLite3 {
   }
 
   void Database::OnChange(int action, char const* dbName, char const* tableName, sqlite3_int64 rowId) {
+    // See http://social.msdn.microsoft.com/Forums/en-US/winappswithcsharp/thread/d778c6e0-c248-4a1a-9391-28d038247578
+    // Too many dispatched events fill the Windows Message queue and this will raise an QUOTA_EXCEEDED error
     if (!vacuumRunning) {
       DispatchedHandler^ handler;
       ChangeEvent event;

--- a/SQLite3Component/Database.h
+++ b/SQLite3Component/Database.h
@@ -16,6 +16,9 @@ namespace SQLite3 {
     static Database^ Open(Platform::String^ dbPath);
     static void EnableSharedCache(bool enable);
 
+    Database() : vacuumRunning(false), sqlite(nullptr) {
+    }
+
     virtual ~Database();
 
     void RunAsyncVector(Platform::String^ sql, ParameterVector^ params);
@@ -26,6 +29,8 @@ namespace SQLite3 {
     Platform::String^ AllAsyncMap(Platform::String^ sql, ParameterMap^ params);
     void EachAsyncVector(Platform::String^ sql, ParameterVector^ params, EachCallback^ callback);
     void EachAsyncMap(Platform::String^ sql, ParameterMap^ params, EachCallback^ callback);
+
+    void VacuumAsync();
 
     bool GetAutocommit();
     long long GetLastInsertRowId();
@@ -62,6 +67,7 @@ namespace SQLite3 {
     static void __cdecl UpdateHook(void* data, int action, char const* dbName, char const* tableName, sqlite3_int64 rowId);
     void OnChange(int action, char const* dbName, char const* tableName, sqlite3_int64 rowId);
 
+    bool vacuumRunning;
     Platform::String^ collationLanguage;
     Windows::UI::Core::CoreDispatcher^ dispatcher;
     sqlite3* sqlite;

--- a/SQLite3Component/Statement.cpp
+++ b/SQLite3Component/Statement.cpp
@@ -27,12 +27,20 @@ namespace SQLite3 {
   }
 
   void Statement::Bind(ParameterVector^ params) {
+    if (!params) {
+      return;
+    }
+
     for (unsigned int i = 0; i < params->Size ; ++i) {
       BindParameter(static_cast<int>(i + 1), params->GetAt(i));
     }
   }
 
   void Statement::Bind(ParameterMap^ params) {
+    if (!params) {
+      return;
+    }
+
     for (int i = 0; i < BindParameterCount(); ++i) {
       int index = i + 1;
       auto nameWithoutPrefix = BindParameterName(index).substr(1);

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -202,6 +202,12 @@
       close: function () {
         connection.close();
       },
+      vacuumAsync: function () {
+        return new WinJS.Promise( function(complete) {
+          connection.vacuumAsync();
+          complete();
+        });
+      },
       addEventListener: connection.addEventListener.bind(connection),
       removeEventListener: connection.removeEventListener.bind(connection)
     };


### PR DESCRIPTION
Dispatching too many update events during vacuum raises a SEH in the Windows Message dispatcher. We disable event dispatching during vacuuming now.
