### PR TITLE
Event control and translation

### DIFF
--- a/SQLite3Component/Database.cpp
+++ b/SQLite3Component/Database.cpp
@@ -69,15 +69,16 @@ namespace SQLite3 {
   }
 
   void Database::VacuumAsync() {
-    vacuumRunning = true;
+    bool oldFireEvents = fireEvents;
+    fireEvents = false;
     RunAsync("VACUUM", reinterpret_cast<ParameterVector^>(nullptr));
-    vacuumRunning = false;
+    fireEvents = oldFireEvents;
   }
 
   void Database::OnChange(int action, char const* dbName, char const* tableName, sqlite3_int64 rowId) {
     // See http://social.msdn.microsoft.com/Forums/en-US/winappswithcsharp/thread/d778c6e0-c248-4a1a-9391-28d038247578
     // Too many dispatched events fill the Windows Message queue and this will raise an QUOTA_EXCEEDED error
-    if (!vacuumRunning) {
+    if (fireEvents) {
       DispatchedHandler^ handler;
       ChangeEvent event;
       event.RowId = rowId;
@@ -107,7 +108,7 @@ namespace SQLite3 {
   }
 
   void Database::RunAsyncVector(Platform::String^ sql, ParameterVector^ params) {
-    return RunAsync(sql, params);
+    RunAsync(sql, params);
   }
 
   void Database::RunAsyncMap(Platform::String^ sql, ParameterMap^ params) {

--- a/SQLite3Component/Database.h
+++ b/SQLite3Component/Database.h
@@ -16,7 +16,7 @@ namespace SQLite3 {
     static Database^ Open(Platform::String^ dbPath);
     static void EnableSharedCache(bool enable);
 
-    Database() : vacuumRunning(false), sqlite(nullptr) {
+    Database() : fireEvents(false), sqlite(nullptr) {
     }
 
     virtual ~Database();
@@ -49,6 +49,15 @@ namespace SQLite3 {
       }
     }
 
+    property bool FireEvents {
+      bool get() {
+        return fireEvents;
+      };
+      void set(bool value) {
+        fireEvents = value;
+      };
+    }
+
   private:
     Database(sqlite3* sqlite, Windows::UI::Core::CoreDispatcher^ dispatcher);
 
@@ -67,7 +76,7 @@ namespace SQLite3 {
     static void __cdecl UpdateHook(void* data, int action, char const* dbName, char const* tableName, sqlite3_int64 rowId);
     void OnChange(int action, char const* dbName, char const* tableName, sqlite3_int64 rowId);
 
-    bool vacuumRunning;
+    bool fireEvents;
     Platform::String^ collationLanguage;
     Windows::UI::Core::CoreDispatcher^ dispatcher;
     sqlite3* sqlite;

--- a/SQLite3JS/SQLite3JS.jsproj
+++ b/SQLite3JS/SQLite3JS.jsproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="strings\en-US\resources.resjson" />
+    <PRIResource Include="strings\en-US\secondary.resjson" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\$(WMSJSProjectDirectory)\Microsoft.VisualStudio.$(WMSJSProject).targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SQLite3JS/SQLite3JS.jsproj
+++ b/SQLite3JS/SQLite3JS.jsproj
@@ -72,6 +72,9 @@
   <ItemGroup>
     <ProjectReference Include="..\SQLite3Component\SQLite3Component.vcxproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="strings\en-US\resources.resjson" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\$(WMSJSProjectDirectory)\Microsoft.VisualStudio.$(WMSJSProject).targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SQLite3JS/SQLite3JS.jsproj
+++ b/SQLite3JS/SQLite3JS.jsproj
@@ -44,8 +44,7 @@
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <TargetPlatformVersion>8.0</TargetPlatformVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <PackageCertificateKeyFile>SQLite3JS_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <PackageCertificateThumbprint>74097B4D218EFB7BB78E01A5894E369B9210A584</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>475429737F7E7A58C42577C2EDDCBDF433C2B818</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemGroup>
     <AppxManifest Include="package.appxmanifest">

--- a/SQLite3JS/js/SQLite3.js
+++ b/SQLite3JS/js/SQLite3.js
@@ -217,10 +217,17 @@
       WinJS.Utilities.createEventProperties('update', 'delete', 'insert')
     );
 
-    Object.defineProperty(that, "collationLanguage", {
-      set: function (value) { connection.collationLanguage = value; },
-      get: function () { return connection.collationLanguage; },
-      enumerable: true
+    Object.defineProperties(that, {
+      "collationLanguage": {
+        set: function (value) { connection.collationLanguage = value; },
+        get: function () { return connection.collationLanguage; },
+        enumerable: true
+      },
+      "fireEvents": {
+        set: function (value) { connection.fireEvents = value; },
+        get: function () { return connection.fireEvents; },
+        enumerable: true
+      }
     });
 
     return that;

--- a/SQLite3JS/package.appxmanifest
+++ b/SQLite3JS/package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/2010/manifest">
-  <Identity Name="1a1e8060-a03c-449c-931c-6bceec16e82f" Version="1.0.0.0" Publisher="CN=doo GmbH, OU=Digital ID Class 3 - Microsoft Software Validation v2, O=doo GmbH, L=Bonn, S=Nordrhein Westfalen, C=DE" />
+  <Identity Name="SQLite3JS" Version="1.0.0.0" Publisher="CN=doo GmbH, OU=Digital ID Class 3 - Microsoft Software Validation v2, O=doo GmbH, L=Bonn, S=Nordrhein Westfalen, C=DE" />
   <Properties>
     <DisplayName>SQLite3JS</DisplayName>
     <Description>SQLite3JS</Description>

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -317,6 +317,12 @@
     });
 
     describe('Events', function () {
+      beforeEach(function () {
+        db.fireEvents = true;
+      });
+      afterEach(function () {
+        db.fireEvents = false;
+      });
       function expectEvent(eventName, rowId, callback) {
         var calledEventHandler = false;
 

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -317,10 +317,17 @@
     });
 
     describe("Win8 app translation", function () {
-      it("should translate from database queries", function () {
+      it("should translate from database queries using default resource", function () {
         waitsForPromise(
           db.oneAsync("SELECT APPTRANSLATE(?) AS translation", ["testString1"]).then(function (row) {
             expect(row.translation).toEqual("Hello World!");
+          })
+        );
+      });
+      it("should translate from database queries using specific resource", function () {
+        waitsForPromise(
+          db.oneAsync("SELECT APPTRANSLATE(?,?) AS translation", ["secondary", "testString1"]).then(function (row) {
+            expect(row.translation).toEqual("Goodbye World.");
           })
         );
       });

--- a/SQLite3JS/spec/SQLite3Spec.js
+++ b/SQLite3JS/spec/SQLite3Spec.js
@@ -316,6 +316,16 @@
       });
     });
 
+    describe("Win8 app translation", function () {
+      it("should translate from database queries", function () {
+        waitsForPromise(
+          db.oneAsync("SELECT APPTRANSLATE(?) AS translation", ["testString1"]).then(function (row) {
+            expect(row.translation).toEqual("Hello World!");
+          })
+        );
+      });
+    });
+
     describe('Events', function () {
       beforeEach(function () {
         db.fireEvents = true;

--- a/SQLite3JS/strings/en-US/resources.resjson
+++ b/SQLite3JS/strings/en-US/resources.resjson
@@ -1,0 +1,3 @@
+﻿{
+    "testString1"      : "Hello World!"
+}

--- a/SQLite3JS/strings/en-US/secondary.resjson
+++ b/SQLite3JS/strings/en-US/secondary.resjson
@@ -1,0 +1,3 @@
+﻿{
+    "testString1"              : "Goodbye World."
+}


### PR DESCRIPTION
First commit allows the application to decide whether it wants events at all.

The second adds the `APPTRANSLATE` function which supports translation of strings from app resource bundles so things like `ORDER BY APPTRANSLATE(value)` become possible.
